### PR TITLE
fix: test 3 announcing the wrong test parameters

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -80,7 +80,7 @@ test_three ()
         pgrep $1 > /dev/null
         if [ "$?" -ne 0 ];then
             echo "\r\e[91m[+] Test #3 Failed\e[0m"
-            error_log $1 "Test #3" "Given 4 800 200 200 arguments to $1, no philosopher should die !"
+            error_log $1 "Test #3" "Given 5 800 200 200 arguments to $1, no philosopher should die !"
             error=1
             break
         fi


### PR DESCRIPTION
Hello from 42 SP (São Paulo - Brazil) 🖖🏼

I found a typo on your test.
I fixed it and I believe 5 800 200 200 is the better option here. Because the evaluation asks for that combination.

And this constitutes my very first contribution! Hooray!!